### PR TITLE
Fix Downloads folder dock path

### DIFF
--- a/.config/dock/dock_config.zsh
+++ b/.config/dock/dock_config.zsh
@@ -22,7 +22,7 @@ dockutil --add /System/Applications/iPhone\ Mirroring.app --no-restart
 dockutil --add /System/Applications/System\ Settings.app --no-restart
 
 # Add Downloads folder as a stack in list view
-dockutil --add '~/Downloads' --view list --display folder --no-restart
+dockutil --add "$HOME/Downloads" --view list --display folder --no-restart
 
 # Set additional Dock preferences
 defaults write com.apple.dock minimize-to-application -bool true # Minimize into app icon


### PR DESCRIPTION
## Summary
- fix Downloads path expansion in dock config

## Testing
- `make lint` *(fails: shellcheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc7900088320aa02d5895d7334f3