### PR TITLE
Add SSH-aware segment to Oh My Posh

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -29,6 +29,13 @@ final_space = true
 
   [[blocks.segments]]
     style = 'plain'
+    template = '{{ if or .Env.SSH_CONNECTION .Env.SSH_CLIENT }} 🛰️ {{ end }}'
+    foreground = 'white'
+    background = '#6a5acd'
+    type = 'text'
+
+  [[blocks.segments]]
+    style = 'plain'
     template = ' {{ .HEAD }}{{ if or (.Working.Changed) (.Staging.Changed) }}*{{ end }} <cyan>{{ if gt .Behind 0 }}⇣{{ end }}{{ if gt .Ahead 0 }}⇡{{ end }}</>'
     foreground = 'p:grey'
     background = 'transparent'


### PR DESCRIPTION
## Summary
- tweak `prompt.toml` to display a remote segment when connected via SSH
- pick a calmer color for the remote indicator

## Testing
- `make -f helpers/Makefile lint` *(fails: shellcheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cdc94a048320837c7f6cfe05de56