### PR TITLE
Update lint to cover .zsh files

### DIFF
--- a/helpers/Makefile
+++ b/helpers/Makefile
@@ -1,7 +1,9 @@
 .PHONY: lint bootstrap-macos bootstrap-linux dotbot
 
 lint:
-	shellcheck .bootstrap/**/*.sh
+	shellcheck .bootstrap/**/*.sh \
+	.bootstrap/**/*.zsh \
+	.zsh/*.zsh
 
 bootstrap-macos:
 	./.bootstrap/macos/bootstrap_macos.zsh


### PR DESCRIPTION
## Summary
- extend the lint target to run `shellcheck` on `.zsh` files
- keep existing checks for `.sh` scripts

## Testing
- `make -f helpers/Makefile lint -n`

------
https://chatgpt.com/codex/tasks/task_e_6840d13f94fc832093d9e867c807eef1