### PR TITLE
Fix macOS header in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Macos
+# macOS
 .DS_Store
 
 # Vim


### PR DESCRIPTION
## Summary
- correct the header comment in `.gitignore`

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `make -f helpers/Makefile lint` *(fails: SC2155, SC2016, SC2027, SC2046, SC1091, SC2034)*

------
https://chatgpt.com/codex/tasks/task_e_6840d12336848320a7a56937e9ca2e47