### PR TITLE
Tweak SSH segment style

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -29,9 +29,9 @@ final_space = true
 
   [[blocks.segments]]
     style = 'plain'
-    template = '{{ if or .Env.SSH_CONNECTION .Env.SSH_CLIENT }} 🛰️ {{ end }}'
+    template = '{{ if or .Env.SSH_CONNECTION .Env.SSH_CLIENT }} 🛰️  <green><b>SSH</b></> {{ end }}'
     foreground = 'white'
-    background = '#6a5acd'
+    background = 'transparent'
     type = 'text'
 
   [[blocks.segments]]


### PR DESCRIPTION
## Summary
- remove background from SSH segment
- add bold green "SSH" text next to the satellite emoji

## Testing
- `make -f helpers/Makefile lint` *(fails: shellcheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840da87a92c8320ad7ab0d2da54f96a