### PR TITLE
Add right-aligned SSH indicator

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -27,12 +27,6 @@ final_space = true
     [blocks.segments.properties]
       style = 'full'
 
-  [[blocks.segments]]
-    style = 'plain'
-    template = '{{ if or .Env.SSH_CONNECTION .Env.SSH_CLIENT }} 🛰️  <green><b>SSH</b></> {{ end }}'
-    foreground = 'white'
-    background = 'transparent'
-    type = 'text'
 
   [[blocks.segments]]
     style = 'plain'
@@ -60,6 +54,14 @@ final_space = true
     [blocks.segments.properties]
       threshold = 5000
 
+  [[blocks.segments]]
+    type = 'text'
+    style = 'plain'
+    alignment = 'right'
+    when = "env.SSH_TTY != ''"
+
+      [blocks.segments.properties]
+        text = '🔒 SSH'
 [[blocks]]
   type = 'prompt'
   alignment = 'left'


### PR DESCRIPTION
## Summary
- show `🔒 SSH` on the right side of the prompt only for SSH sessions

## Testing
- `bash -lc 'git status --short'`


------
https://chatgpt.com/codex/tasks/task_e_6840ddc8e634832080f8fde08c88a085