### PR TITLE
Fix SSH indicator visibility in OMP prompt

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -58,10 +58,7 @@ final_space = true
     type = 'text'
     style = 'plain'
     alignment = 'right'
-    when = "env.SSH_TTY != ''"
-
-      [blocks.segments.properties]
-        text = '🔒 SSH'
+    template = '{{ if or (ne .Env.SSH_CONNECTION "") (ne .Env.SSH_TTY "") }}🔒 SSH{{ end }}'
 [[blocks]]
   type = 'prompt'
   alignment = 'left'


### PR DESCRIPTION
## Summary
- show SSH indicator when `SSH_CONNECTION` or `SSH_TTY` is set

## Testing
- `make -C helpers lint` *(fails: `shellcheck: No such file or directory`)*
- `SSH_CONNECTION=1 ~/.local/bin/oh-my-posh prompt debug --config .config/ohmyposh/prompt.toml | sed -n '1,20p'`


------
https://chatgpt.com/codex/tasks/task_e_6840e1c04d2c83209c8a7a6982c24443