### PR TITLE
Adjust oh-my-posh rprompt line

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -15,7 +15,8 @@ final_space = true
 [[blocks]]
   type = 'prompt'
   alignment = 'left'
-  newline = true
+  # keep the prompt and rprompt on the same line
+  newline = false
 
   [[blocks.segments]]
     style = 'plain'


### PR DESCRIPTION
## Summary
- keep rprompt on same line as left prompt

## Testing
- `oh-my-posh --version`
- `oh-my-posh print right --config .config/ohmyposh/prompt.toml --shell bash --pwd /workspace/.dotfiles --terminal-width 80 | busybox hexdump -C`


------
https://chatgpt.com/codex/tasks/task_e_6840e64753348320b45c4c2cc0d17589