### PR TITLE
Fix rprompt alignment and color

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -44,6 +44,8 @@ final_space = true
 [[blocks]]
   type = 'rprompt'
   overflow = 'hidden'
+  # keep the rprompt on the same line as the left prompt
+  newline = false
 
   [[blocks.segments]]
     style = 'plain'
@@ -60,6 +62,7 @@ final_space = true
     style = 'plain'
     alignment = 'right'
     template = '{{ if or (ne .Env.SSH_CONNECTION "") (ne .Env.SSH_TTY "") }}🔒 SSH{{ end }}'
+    foreground = 'green'
 [[blocks]]
   type = 'prompt'
   alignment = 'left'


### PR DESCRIPTION
## Summary
- keep rprompt on same line as path
- color padlock SSH indicator green

## Testing
- `make lint` *(fails: shellcheck missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e80deb008320bfb4f5140c758ed7