### PR TITLE
Update Oh My Posh theme

### DIFF
--- a/.config/ohmyposh/prompt.toml
+++ b/.config/ohmyposh/prompt.toml
@@ -1,64 +1,45 @@
-console_title_template = '{{ .Shell }} in {{ .Folder }}'
-version = 3
-final_space = true
-
-[secondary_prompt]
-  template = '❯❯ '
-  foreground = 'magenta'
-  background = 'transparent'
-
-[transient_prompt]
-  template = '❯ '
-  foreground_templates = ['{{if gt .Code 0}}red{{end}}', '{{if eq .Code 0}}magenta{{end}}']
-  background = 'transparent'
+name = "custom-ssh-oneline"
 
 [[blocks]]
-  type      = 'prompt'
-  alignment = 'left'
-  newline   = false    # keep the prompt and rprompt on the same line
+  alignment = "left"
 
   [[blocks.segments]]
-    type       = 'path'
-    style      = 'plain'
-    template   = '{{ .Path }}'
-    foreground = 'blue'
-    background = 'transparent'
-
+    type  = "path"
+    style = "folder"
     [blocks.segments.properties]
-      style = 'full'
-
+      theme            = "blue"
+      home_icon        = "~"
+      truncate_to_repo = true
 
   [[blocks.segments]]
-    type       = 'git'
-    style      = 'plain'
-    template   = ' {{ .HEAD }}{{ if or (.Working.Changed) (.Staging.Changed) }}*{{ end }}<cyan>{{ if gt .Behind 0 }}⇣{{ end }}{{ if gt .Ahead 0 }}⇡{{ end }}</>'
-    foreground = 'p:grey'
-    background = 'transparent'
-
+    type  = "git"
+    style = "powerline"
     [blocks.segments.properties]
-      branch_icon  = ' '
-      commit_icon  = '@'
-      fetch_status = true
+      branch_icon    = " "
+      display_status = true
+      display_fetch  = true
+      theme          = "p:grey"
 
 [[blocks]]
-  type      = 'rprompt'
-  alignment = 'right'
-  newline   = false   # attach to the same line as the path/git above
+  alignment = "right"
 
   [[blocks.segments]]
-    type       = 'text'
-    style      = 'plain'
-    template   = '{{ if or (ne .Env.SSH_CONNECTION "") (ne .Env.SSH_TTY "") }}🔒 SSH{{ end }}'
-    foreground = 'green'
-    background = 'transparent'
+    type  = "ssh"
+    style = "powerline"
+    [blocks.segments.properties]
+      icon            = "🔒"
+      display_hostname = false
+      theme           = "green"
+
 [[blocks]]
-  type      = 'prompt'
-  alignment = 'left'
-  newline   = true    # force a newline so the arrow is below line 1
+  alignment = "left"
+  newline   = true
 
   [[blocks.segments]]
-    type               = 'text'
-    style              = 'plain'
-    template           = '❯'
-    background         = 'transparent'
-    foreground_templates = ['{{if gt .Code 0}}red{{end}}', '{{if eq .Code 0}}magenta{{end}}']
+    type  = "prompt"
+    style = "plain"
+    [blocks.segments.properties]
+      character     = "❯"
+      color_success = "magenta"
+      color_error   = "red"
+      add_newline   = false


### PR DESCRIPTION
## Summary
- update `prompt.toml` with a minimal theme
  - shows path+git on the left
  - displays a lock icon when in SSH
  - keeps the prompt arrow on a new line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ed81b6648320bee4b9c3c846b2a2