### PR TITLE
Alias ssh config in dotbot

### DIFF
--- a/.config/dotbot/install.conf.yaml
+++ b/.config/dotbot/install.conf.yaml
@@ -10,6 +10,7 @@
     - ~/.config
     - "~/Library/Application Support/Sublime Text/Packages/User"
     - "~/Library/Application Support/Sublime Text/Installed Packages"
+    - ~/.ssh
 
 - link:
     ~/.config: .config
@@ -18,10 +19,10 @@
     ~/.zshenv: .zsh/.zshenv
     ~/.zprofile: .zsh/.zprofile
     ~/.zshrc: .zsh/.zshrc
+    ~/.ssh/config: ssh/config
     /opt/homebrew/etc/dnsmasq.conf: .config/dnsmasq/dnsmasq.conf
     "~/Library/Application Support/Sublime Text/Packages/User": .config/sublime/User
     "~/Library/Application Support/Sublime Text/Installed Packages": .config/sublime/Installed Packages
 
 - shell:
-    - [git submodule update --init --recursive, Installing submodules]
-    - [rm -f ~/.bashrc ~/.bash_profile, Removing Bash configuration files]
+    - [git submodule update --init --recursive, Installing submodules]    - [rm -f ~/.bashrc ~/.bash_profile, Removing Bash configuration files]


### PR DESCRIPTION
## Summary
- ensure `~/.ssh` exists during setup
- link `ssh/config` to `~/.ssh/config` in Dotbot

## Testing
- `make -f helpers/Makefile lint` *(fails: `shellcheck` not found)*
- `make -f helpers/Makefile dotbot`

------
https://chatgpt.com/codex/tasks/task_e_686ea33442088320a7b1e8fa54d2381b