### PR TITLE
Centralize ZSH plugin configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 .zsh/.zcompdump
 .zsh/.zsh_history
 .zsh/.zsh_sessions/
-.zsh/.zshplugins/
 
 # Zsh compiled files
 **/*.zwc

--- a/.zsh/.zshrc
+++ b/.zsh/.zshrc
@@ -76,49 +76,6 @@ FZF_CONFIG="$HOME/.config/fzf/config.fzf"
 [[ -f "$FZF_CONFIG" ]] && source "$FZF_CONFIG"
 
 
-# Paths where zsh-autosuggestions might be installed
-ZSH_AUTOSUGGEST_LOCATIONS=(
-    "/usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-    "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh"
-    "$(brew --prefix zsh-autosuggestions 2>/dev/null)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-    "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
-    "$HOME/.dotfiles/.zsh/.zshplugins/zsh-autosuggestions/zsh-autosuggestions.zsh"
-)
-
-for plugin in "${ZSH_AUTOSUGGEST_LOCATIONS[@]}"; do
-    if [ -f "$plugin" ]; then
-        source "$plugin"
-        break
-    fi
-done
-
-# Auto-suggestion Settings
-ZSH_AUTOSUGGEST_STRATEGY=(history completion)
-ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=20
-ZSH_AUTOSUGGEST_USE_ASYNC=true
-ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#808080'
-
-# Additional key bindings for autosuggestions
-bindkey '^[[1;3C' forward-word      # Alt + →
-bindkey '^[[1;5C' forward-word      # Ctrl + →
-
-
-# You-Should-Use Configuration
-YSU_PLUGIN_PATHS=(
-    "$HOME/.dotfiles/.zsh/.zshplugins/zsh-you-should-use/you-should-use.plugin.zsh"
-    "/usr/share/zsh-you-should-use/zsh-you-should-use.plugin.zsh"
-    "$(brew --prefix 2>/dev/null)/share/zsh-you-should-use/you-should-use.plugin.zsh"
-)
-
-for ysu_plugin in "${YSU_PLUGIN_PATHS[@]}"; do
-    if [ -f "$ysu_plugin" ]; then
-        source "$ysu_plugin"
-        break
-    fi
-done
-
-YSU_MESSAGE_POSITION="after"  # Show alias message after command
-YSU_MODE=ALL                  # Show all matching aliases
 
 #------------------------------------------------------------------------------
 # Terminal UI and Appearance
@@ -140,16 +97,8 @@ TRAPALRM() {
     zle reset-prompt
 }
 
-# Syntax Highlighting (Must be last)
-ZSH_SYNTAX_HIGHLIGHT_LOCATIONS=(
-    "$HOME/.dotfiles/.zsh/.zshplugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-    "/usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-    "$(brew --prefix 2>/dev/null)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-)
-
-for syntax_plugin in "${ZSH_SYNTAX_HIGHLIGHT_LOCATIONS[@]}"; do
-    if [ -f "$syntax_plugin" ]; then
-        source "$syntax_plugin"
-        break
-    fi
+# Source every ZSH plugin config
+for cfg in "$HOME/.dotfiles/.zsh/config/"*.zsh; do
+  source "$cfg"
 done
+

--- a/.zsh/config/autosuggestions.zsh
+++ b/.zsh/config/autosuggestions.zsh
@@ -1,0 +1,23 @@
+# zsh-autosuggestions
+ZSH_AUTOSUGGEST_LOCATIONS=(
+  "/usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+  "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh"
+  "$(brew --prefix zsh-autosuggestions 2>/dev/null)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+  "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+  "$HOME/.dotfiles/.zsh/.zshplugins/zsh-autosuggestions/zsh-autosuggestions.zsh"
+)
+
+for plugin in "${ZSH_AUTOSUGGEST_LOCATIONS[@]}"; do
+  if [ -f "$plugin" ]; then
+    source "$plugin"
+    break
+  fi
+done
+
+ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=20
+ZSH_AUTOSUGGEST_USE_ASYNC=true
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#808080'
+
+bindkey '^[[1;3C' forward-word
+bindkey '^[[1;5C' forward-word

--- a/.zsh/config/syntax-highlighting.zsh
+++ b/.zsh/config/syntax-highlighting.zsh
@@ -1,0 +1,4 @@
+# zsh-syntax-highlighting
+SYNTAX_DIR="$HOME/.dotfiles/.zsh/.zshplugins/zsh-syntax-highlighting"
+source "$SYNTAX_DIR/themes/catppuccin_frappe-zsh-syntax-highlighting.zsh"
+source "$SYNTAX_DIR/zsh-syntax-highlighting.zsh"

--- a/.zsh/config/you-should-use.zsh
+++ b/.zsh/config/you-should-use.zsh
@@ -1,0 +1,16 @@
+# you-should-use
+YSU_PLUGIN_PATHS=(
+  "$HOME/.dotfiles/.zsh/.zshplugins/zsh-you-should-use/you-should-use.plugin.zsh"
+  "/usr/share/zsh-you-should-use/zsh-you-should-use.plugin.zsh"
+  "$(brew --prefix 2>/dev/null)/share/zsh-you-should-use/you-should-use.plugin.zsh"
+)
+
+for ysu_plugin in "${YSU_PLUGIN_PATHS[@]}"; do
+  if [ -f "$ysu_plugin" ]; then
+    source "$ysu_plugin"
+    break
+  fi
+done
+
+YSU_MESSAGE_POSITION="after"
+YSU_MODE=ALL


### PR DESCRIPTION
## Summary
- stop ignoring `.zsh/.zshplugins/`
- trim plugin logic out of `.zshrc`
- add a `config/` directory for individual plugin boot scripts
- autoload every plugin config from `.zshrc`

## Testing
- `apt-get update`
- `apt-get install -y xxd`

------
https://chatgpt.com/codex/tasks/task_e_6874176d7c748320907c73574d3fdca0